### PR TITLE
Add support execute modules on load

### DIFF
--- a/router.js
+++ b/router.js
@@ -152,6 +152,17 @@ define([], function() {
 
             // Load the route's module
             require([route.moduleId], function(module) {
+
+              // Execute module if it function
+              // Execute exports.default if it exist
+              if (typeof module != 'undefined') {
+                if (typeof module == 'function') {
+                  module();
+                } else if ('default' in module) {
+                  module.default();
+                }
+              }
+
               // Make sure this is still the active route from when loadCurrentRoute was called. The asynchronous nature
               // of AMD loaders means we could have fireed multiple hashchanges or popstates before the AMD module finished
               // loading. If we navigate to route /a then navigate to route /b but /b finishes loading before /a we don't


### PR DESCRIPTION
Execute route default function if it function

```javascript
export default () => {
  console.log('Day review loaded')
}
```
-> Babel ->
```javascript
define(['exports'], function (exports) {
  'use strict';

  Object.defineProperty(exports, "__esModule", {
    value: true
  });

  // Executed in router after loading
  exports.default = function () {
    console.log('Day review loaded');
  };
});
```